### PR TITLE
Add PropOptions example

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,29 @@ export default Vue.extend({
 });
 ```
 
+## How to enable type check on default values and validator functions of a property?
+
+Like `PropType`, there is also `PropOptions`, which enables you to set the type information for the whole property, not only the type definition itself.
+
+
+```ts
+import Vue, { PropOptions } from 'vue';
+import { Product } from '@/interfaces/product';
+
+export default Vue.extend({
+  name: 'MyComponent',
+  props: {
+    products: {
+      type: Array,
+      default: () => [],
+      validator: function (value) {
+        // ... your validation code
+      }
+    } as PropOptions<Product[]>
+  },
+});
+```
+
 ## Conclusion
 
 If something's been bugging you with Vue + TypeScript, please open an issue to discuss having a recipe added!


### PR DESCRIPTION
Like `PropType`, there is also `PropOptions`, which enables you to set the type information for the whole property, not only the type definition itself.

We use those more often in our team than the `PropType` annotation, as it seems more complete.

This pull request adds an example add the end of the file, before the conclusion part.

Let me know if this is something you see as valuable or not to add to the cookbook.

ps. I found it easier to open an MR and propose the change than opening an issue for that.